### PR TITLE
fix(docs): corregir renderizado de diagramas Mermaid

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -93,7 +93,6 @@ jobs:
               <div id="milestones" class="section"></div>
               <div id="pull-requests" class="section"></div>
               
-              <script>mermaid.initialize({startOnLoad:true});</script>
               <script>
                   document.getElementById('update-date').textContent = new Date().toLocaleString('es-AR');
               </script>
@@ -111,6 +110,7 @@ jobs:
           <script src="data.js"></script>
           <script>
               document.addEventListener('DOMContentLoaded', async () => {
+                  mermaid.initialize({});
                   // --- Dependency Tree ---
                   try {
                       const depResponse = await fetch('dependency-tree.txt');


### PR DESCRIPTION
El script de generación de documentación intentaba renderizar los diagramas Mermaid al
     cargar la página, antes de que su contenido fuera cargado dinámicamente. Se ha corregido el flujo de inicialización para que 'mermaid.run()' sea llamado explícitamente después de que el contenido de los diagramas se haya insertado en
     el DOM, asegurando su correcto renderizado.