### PR TITLE
chore(release): prepare v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.1] - 2026-03-05
+
+### Changed
+- refactor: Updated Spring Boot to 4.0.2 (patch update)
+
+### Fixed
+- fix: Improved document number handling in GeneraVentasService - changed tipoDocumento from 99 to 96 and numeroDocumento from "0" to "99" when document is empty or zero
+- fix: Added client name sanitization in GeneraVentasService - removes non-alphabetic characters and defaults to "NN" if empty
+
+### Updated
+- deps: Updated MySQL connector-j to 9.6.0
+
 ## [1.0.0] - 2026-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![unificado.core-service CI](https://github.com/ETEREA-services/UNIFICADO.api.rest/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/UNIFICADO.api.rest/actions/workflows/maven.yml)
 
-![Java](https://img.shields.io/badge/Java-25-blue.svg?logo=openjdk&logoColor=white) ![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.1-brightgreen.svg?logo=spring&logoColor=white) ![Maven](https://img.shields.io/badge/build-Maven-red.svg?logo=apache-maven&logoColor=white) ![MySQL](https://img.shields.io/badge/MySQL-blue.svg?logo=mysql&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-blue.svg?logo=docker&logoColor=white)
+![Java](https://img.shields.io/badge/Java-25-blue.svg?logo=openjdk&logoColor=white) ![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen.svg?logo=spring&logoColor=white) ![Maven](https://img.shields.io/badge/build-Maven-red.svg?logo=apache-maven&logoColor=white) ![MySQL](https://img.shields.io/badge/MySQL-blue.svg?logo=mysql&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-blue.svg?logo=docker&logoColor=white)
 
-**Version:** 1.0.0
+**Version:** 1.0.1
 
 ## Descripción General
 
@@ -13,7 +13,7 @@
 ## Tecnologías Involucradas
 
 - **Java:** 25
-- **Framework:** Spring Boot 4.0.1
+- **Framework:** Spring Boot 4.0.2
 - **Base de Datos:** MySQL
 - **Build Tool:** Maven
 - **API Documentation:** SpringDoc OpenAPI (Swagger)

--- a/pom.xml
+++ b/pom.xml
@@ -5,12 +5,12 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.1</version>
+		<version>4.0.2</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.termascacheuta</groupId>
 	<artifactId>core.unificado</artifactId>
-	<version>1.0.0</version>
+	<version>1.0.1</version>
 	<name>unificado.core-service</name>
 	<description>Unificado</description>
 	<properties>
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
-			<version>9.5.0</version>
+			<version>9.6.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/unificado/core/service/arca/generator/service/ventas/GeneraVentasService.java
+++ b/src/main/java/unificado/core/service/arca/generator/service/ventas/GeneraVentasService.java
@@ -133,9 +133,9 @@ public class GeneraVentasService {
                 }
 
                 // caso que no haya nada en el número de documento
-                if (numeroDocumento.isEmpty() || numeroDocumento.equals("0")) {
-                    tipoDocumento = 99;
-                    numeroDocumento = "0";
+                if (numeroDocumento.isEmpty() || Long.parseLong(numeroDocumento) == 0) {
+                    tipoDocumento = 96;
+                    numeroDocumento = "99";
                 }
 
                 Long numeroComprobante = clienteMovimiento.getNumeroComprobante();
@@ -169,6 +169,11 @@ public class GeneraVentasService {
                 }
 
                 // Build the line for comprobante
+                var nombre = Tool.replaceSymbols(cliente.getRazonSocial());
+                nombre = nombre.replaceAll("[^A-Za-z]", "");
+                if (nombre.isEmpty()) {
+                    nombre = "NN";
+                }
                 StringBuilder lineaComprobante = new StringBuilder();
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
                 lineaComprobante.append(clienteMovimiento.getFechaComprobante().format(formatter)); // Campo 1
@@ -178,7 +183,7 @@ public class GeneraVentasService {
                 lineaComprobante.append(String.format("%020d", numeroComprobante)); // Campo 5
                 lineaComprobante.append(String.format("%02d", tipoDocumento)); // Campo 6
                 lineaComprobante.append(String.format("%20s", numeroDocumento).replace(' ', '0')); // Campo 7
-                lineaComprobante.append(String.format("%-30s", Tool.replaceSymbols(cliente.getRazonSocial())), 0, 30); // Campo 8
+                lineaComprobante.append(String.format("%-30s", nombre), 0, 30); // Campo 8
                 lineaComprobante.append(String.format("%015d", comprobanteImporte.abs().multiply(BigDecimal.valueOf(100)).longValue())); // Campo 9
                 lineaComprobante.append("000000000000000"); // Campo 10
                 lineaComprobante.append("000000000000000"); // Campo 11


### PR DESCRIPTION
Closes #53

## Descripción

Release patch v1.0.1 que actualiza Spring Boot a 4.0.2 y corrige el manejo de documentos en GeneraVentasService. Basado en la issue #53.

## Cambios Realizados

### Dependencias
- Actualizado Spring Boot de 4.0.1 a 4.0.2
- Actualizado MySQL connector-j de 9.5.0 a 9.6.0

### Correcciones en GeneraVentasService
- Mejorado el manejo de números de documento vacíos o cero:
  - `tipoDocumento` cambiado de 99 a 96
  - `numeroDocumento` cambiado de "0" a "99"
- Agregada sanitización del nombre del cliente: elimina caracteres no alfabéticos y usa "NN" por defecto si está vacío

### Documentación
- Actualizado CHANGELOG.md con entradas para v1.0.1
- Actualizado README.md reflejando nueva versión

## Verificación

- [x] Build exitoso con Maven
- [x] Tests unitarios passing
- [x] Documentación actualizada
