### PR TITLE
release(v1.1.0): dependency updates, CI/CD improvements and timezone bugfix

### DIFF
--- a/.github/workflows/generate-docs.yml
+++ b/.github/workflows/generate-docs.yml
@@ -2,8 +2,6 @@ name: Generate Documentation
 
 on:
   pull_request:
-    branches:
-      - main
     types: [opened, synchronize, reopened]
   push:
     branches: [main]
@@ -20,14 +18,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Set up JDK 24
-        uses: actions/setup-java@v4
+      - name: Set up JDK 25
+        uses: actions/setup-java@v5
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
           cache: maven
 
@@ -79,6 +77,7 @@ jobs:
               <div id="component-diagram" class="section"></div>
               <div id="erd-unificado" class="section"></div>
               <div id="balance-sequence-diagram" class="section"></div>
+              <div id="generation-sequence-diagram" class="section"></div>
               
               <div id="dependencies" class="section">
                   <h2>🌳 Grafo de Dependencias</h2>
@@ -133,7 +132,8 @@ jobs:
                   const diagramConfigs = [
                       { id: 'component-diagram', path: 'diagrams/mermaid/component-diagram.mmd', title: '🏛️ Diagrama de Componentes' },
                       { id: 'erd-unificado', path: 'diagrams/mermaid/erd-unificado.mmd', title: '🌐 Diagrama de Entidad-Relación' },
-                      { id: 'balance-sequence-diagram', path: 'diagrams/mermaid/balance-sequence-diagram.mmd', title: '🔄 Diagrama de Secuencia: Cálculo de Balance' }
+                      { id: 'balance-sequence-diagram', path: 'diagrams/mermaid/balance-sequence-diagram.mmd', title: '🔄 Diagrama de Secuencia: Cálculo de Balance' },
+                      { id: 'generation-sequence-diagram', path: 'diagrams/mermaid/generation-sequence-diagram.mmd', title: '📊 Diagrama de Secuencia: Generación de Compras' }
                   ];
 
                   // Insert titles and mermaid divs first
@@ -267,26 +267,10 @@ jobs:
             git push --set-upstream https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.wiki.git master
           fi
 
-      - name: Debug - List Mermaid files
-        run: |
-          echo "Archivos Mermaid en docs/diagrams/mermaid/:"
-          ls -l docs/diagrams/mermaid/ || echo "No existe docs/diagrams/mermaid/"
-
-      - name: Prepare artifact for deployment
-        run: |
-          # Garantizar que los archivos Mermaid estén en docs/diagrams/mermaid/
-          mkdir -p docs/diagrams/mermaid
-          if [ -d diagrams/mermaid ]; then
-            cp -v diagrams/mermaid/*.mmd docs/diagrams/mermaid/ 2>/dev/null || true
-          fi
-          echo "Archivos Mermaid finales en docs/diagrams/mermaid/:"
-          ls -l docs/diagrams/mermaid/ || echo "No existe docs/diagrams/mermaid/"
-          mkdir -p _site
-          cp -r docs/* _site/
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
-          path: _site
+          path: docs
 
   deploy-pages:
     needs: generate-docs
@@ -301,4 +285,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -13,24 +13,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Fetch all history for all branches and tags.
           # SonarCloud needs this to perform analysis on PRs.
           fetch-depth: 0
       - name: Set up JDK 25
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '25'
           distribution: 'temurin'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -54,17 +54,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Extract metadata for JVM Docker image
         id: meta-jvm
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ secrets.DOCKER_IMAGE_NAME }}
           # Add a '-jvm' suffix to tags to differentiate them
@@ -75,10 +75,10 @@ jobs:
             latest
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and push JVM Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           # Point to the new JVM-specific Dockerfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2026-07-14
+
+### Changed
+- deps: Updated Spring Boot parent from 4.0.2 to 4.1.0 (minor update)
+- deps: Updated MySQL connector-j from 9.6.0 to 9.7.0
+- deps: Updated springdoc-openapi-starter-webmvc-ui from 3.0.1 to 3.0.3
+- deps: Updated mockwebserver from 5.3.2 to 5.4.0
+- ci: Updated GitHub Actions to latest versions (checkout@v6, setup-java@v5, cache@v5, docker actions@v4-v7, upload-pages-artifact@v4, deploy-pages@v5)
+- ci: Simplified docs pipeline by removing intermediate _site copy step
+- ci: Removed branches filter on pull_request trigger for docs workflow
+
+### Fixed
+- fix: Corrected JsonFormat timezone pattern from `ssZ` to `ssXX` in CuentaMovimientoUnificado, NegocioCoreCliente, and NegocioCoreClienteMovimiento for proper ISO 8601 timezone offset handling
+
+### Documentation
+- docs: Added generation-sequence-diagram to the documentation pipeline (was missing from diagramConfigs)
+
 ## [1.0.1] - 2026-03-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![unificado.core-service CI](https://github.com/ETEREA-services/UNIFICADO.api.rest/actions/workflows/maven.yml/badge.svg?branch=main)](https://github.com/ETEREA-services/UNIFICADO.api.rest/actions/workflows/maven.yml)
 
-![Java](https://img.shields.io/badge/Java-25-blue.svg?logo=openjdk&logoColor=white) ![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.0.2-brightgreen.svg?logo=spring&logoColor=white) ![Maven](https://img.shields.io/badge/build-Maven-red.svg?logo=apache-maven&logoColor=white) ![MySQL](https://img.shields.io/badge/MySQL-blue.svg?logo=mysql&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-blue.svg?logo=docker&logoColor=white)
+![Java](https://img.shields.io/badge/Java-25-blue.svg?logo=openjdk&logoColor=white) ![Spring Boot](https://img.shields.io/badge/Spring%20Boot-4.1.0-brightgreen.svg?logo=spring&logoColor=white) ![Maven](https://img.shields.io/badge/build-Maven-red.svg?logo=apache-maven&logoColor=white) ![MySQL](https://img.shields.io/badge/MySQL-blue.svg?logo=mysql&logoColor=white) ![Docker](https://img.shields.io/badge/Docker-blue.svg?logo=docker&logoColor=white)
 
-**Version:** 1.0.1
+**Version:** 1.1.0
 
 ## Descripción General
 
@@ -13,7 +13,7 @@
 ## Tecnologías Involucradas
 
 - **Java:** 25
-- **Framework:** Spring Boot 4.0.2
+- **Framework:** Spring Boot 4.1.0
 - **Base de Datos:** MySQL
 - **Build Tool:** Maven
 - **API Documentation:** SpringDoc OpenAPI (Swagger)
@@ -23,7 +23,7 @@
 
 ### Prerrequisitos
 
-- JDK 24 o superior
+- JDK 25 o superior
 - Apache Maven
 - Docker (opcional)
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>4.0.2</version>
+		<version>4.1.0</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.termascacheuta</groupId>
@@ -45,13 +45,13 @@
 		<dependency>
 			<groupId>com.mysql</groupId>
 			<artifactId>mysql-connector-j</artifactId>
-			<version>9.6.0</version>
+			<version>9.7.0</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>3.0.1</version>
+			<version>3.0.3</version>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -75,7 +75,7 @@
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
 			<artifactId>mockwebserver</artifactId>
-			<version>5.3.2</version>
+			<version>5.4.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/unificado/core/service/cuentamovimientounificado/model/CuentaMovimientoUnificado.java
+++ b/src/main/java/unificado/core/service/cuentamovimientounificado/model/CuentaMovimientoUnificado.java
@@ -32,11 +32,11 @@ public class CuentaMovimientoUnificado extends Auditable {
     private Long numeroCuenta;
 
     @Column(name = "mco_desde")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime desde;
 
     @Column(name = "mco_hasta")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime hasta;
 
     @Column(name = "mco_debita")

--- a/src/main/java/unificado/core/service/extern/negocio/core/clientemovimiento/domain/NegocioCoreCliente.java
+++ b/src/main/java/unificado/core/service/extern/negocio/core/clientemovimiento/domain/NegocioCoreCliente.java
@@ -20,7 +20,7 @@ public class NegocioCoreCliente {
     private String razonSocial;
     private String nombreFantasia;
 
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaRestaurant;
 
     private Integer cantidadPaxs;

--- a/src/main/java/unificado/core/service/extern/negocio/core/clientemovimiento/domain/NegocioCoreClienteMovimiento.java
+++ b/src/main/java/unificado/core/service/extern/negocio/core/clientemovimiento/domain/NegocioCoreClienteMovimiento.java
@@ -21,12 +21,12 @@ public class NegocioCoreClienteMovimiento {
     private Integer puntoVenta = 0;
     @Builder.Default
     private Long numeroComprobante = 0L;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaComprobante;
     @Builder.Default
     private Long clienteId = 0L;
     private Integer legajoId;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaVencimiento;
     @Builder.Default
     private Integer negocioId = 0;
@@ -46,7 +46,7 @@ public class NegocioCoreClienteMovimiento {
     private BigDecimal montoIvaRni = BigDecimal.ZERO;
     @Builder.Default
     private BigDecimal reintegroTurista = BigDecimal.ZERO;
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssZ", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ssXX", timezone = "UTC")
     private OffsetDateTime fechaContable;
     @Builder.Default
     private Integer ordenContable = 0;


### PR DESCRIPTION
Closes #55

## Descripción
Release **v1.1.0** con actualización de dependencias, mejoras en CI/CD, corrección de bug en formato de timezone y mejoras en documentación. Este PR consolida todos los cambios preparados para la release v1.1.0.

---

## Cambios Realizados

### Dependencias (pom.xml)
- Spring Boot parent: `4.0.2` → `4.1.0`
- mysql-connector-j: `9.6.0` → `9.7.0`
- springdoc-openapi-starter-webmvc-ui: `3.0.1` → `3.0.3`
- mockwebserver: `5.3.2` → `5.4.0`

### CI/CD (workflows)
- **generate-docs.yml:** Actions actualizados (checkout@v6, setup-java@v5 con JDK 25, upload-pages-artifact@v4, deploy-pages@v5). Eliminados pasos de debug y copia intermedia. Agregado generation-sequence-diagram al pipeline.
- **maven.yml:** Actions actualizados (checkout@v6, setup-java@v5, cache@v5, docker/login-action@v4, docker/metadata-action@v6, docker/setup-buildx-action@v4, docker/build-push-action@v7).

### Bugfix
- Corregido patrón de timezone en `@JsonFormat` de `ssZ` a `ssXX` en 3 clases:
  - `CuentaMovimientoUnificado` (campos `desde`, `hasta`)
  - `NegocioCoreCliente` (campo `fechaRestaurant`)
  - `NegocioCoreClienteMovimiento` (campos `fechaComprobante`, `fechaVencimiento`, `fechaContable`)

### Documentación
- `CHANGELOG.md` actualizado con entrada `[1.1.0] - 2026-07-14`
- `README.md` actualizado: versión → `1.1.0`, Spring Boot → `4.1.0`, prerrequisito JDK → `25+`

---

## Verificación
- Compilación exitosa con `mvn clean compile`
- Patrones de timezone corregidos verificados en las 3 clases afectadas
- GitHub Actions workflows actualizados con versiones最新imas
- No se esperan breaking changes (Spring Boot minor update + dependencias compatibles hacia atrás)
